### PR TITLE
Update user-data.pkrtpl.hcl

### DIFF
--- a/builds/linux/ubuntu-server-20-04-lts/http/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/http/user-data.pkrtpl.hcl
@@ -28,9 +28,6 @@ autoinstall:
     - open-vm-tools
   user-data:
     disable_root: false
-    package_update: true
-    package_upgrade: true
-    package_reboot_if_required: true
   late-commands:
     - 'sed -i "s/dhcp4: true/&\n      dhcp-identifier: mac/" /target/etc/netplan/00-installer-config.yaml'
     - echo '${build_username} ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/${build_username}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

<!-- 
    Please provide a clear and concise description of the pull request.
-->

Removes the following from `user-data` and allows updates to occur post:
- `package_update: true`
- `package_upgrade: true`
- `package_reboot_if_required: true`

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

<!-- 
    Please describe the current behavior that you are modifying or link to a relevant issue. 
-->

Addresses the lock occasionally seen when running a build.

```
==> vsphere-iso.linux-ubuntu-server: Provisioning with shell script: ../../../scripts/linux/ubuntu-server-2x.sh
==> vsphere-iso.linux-ubuntu-server: + export BUILD_USERNAME
==> vsphere-iso.linux-ubuntu-server: + export BUILD_KEY
    vsphere-iso.linux-ubuntu-server: > Updating the guest operating system ...
==> vsphere-iso.linux-ubuntu-server: + export ANSIBLE_USERNAME
==> vsphere-iso.linux-ubuntu-server: + export ANSIBLE_KEY
==> vsphere-iso.linux-ubuntu-server: + echo > Updating the guest operating system ...
==> vsphere-iso.linux-ubuntu-server: + sudo apt-get update
    vsphere-iso.linux-ubuntu-server: Hit:1 http://lu.archive.ubuntu.com/ubuntu focal InRelease
    vsphere-iso.linux-ubuntu-server: Hit:2 http://lu.archive.ubuntu.com/ubuntu focal-updates InRelease
    vsphere-iso.linux-ubuntu-server: Hit:3 http://lu.archive.ubuntu.com/ubuntu focal-backports InRelease
    vsphere-iso.linux-ubuntu-server: Hit:4 http://lu.archive.ubuntu.com/ubuntu focal-security InRelease
    vsphere-iso.linux-ubuntu-server: Reading package lists...
==> vsphere-iso.linux-ubuntu-server: + sudo apt-get upgrade -y
==> vsphere-iso.linux-ubuntu-server: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2078 (apt-get)
==> vsphere-iso.linux-ubuntu-server: E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
==> vsphere-iso.linux-ubuntu-server: Script exited with non-zero exit status: 100.Allowed exit codes are: [0]
```

Moves all package updates to post.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: https://github.com/rainpole/packer-vsphere/issues/42
Closes: https://github.com/rainpole/packer-vsphere/issues/42

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
