### PR TITLE
Update boot_command for rhel/variants

### DIFF
--- a/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
@@ -76,7 +76,7 @@ source "vsphere-iso" "linux-almalinux" {
   }
   boot_order       = var.vm_boot_order
   boot_wait        = var.vm_boot_wait
-  boot_command     = ["up", "e", "<down><down><end><wait>", "text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
+  boot_command     = ["up", "e", "<down><down><end><wait>", "text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
   shutdown_timeout = var.common_shutdown_timeout

--- a/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
+++ b/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
@@ -76,7 +76,7 @@ source "vsphere-iso" "linux-centos-linux" {
   }
   boot_order       = var.vm_boot_order
   boot_wait        = var.vm_boot_wait
-  boot_command     = ["up", "e", "<down><down><end><wait>", "text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
+  boot_command     = ["up", "e", "<down><down><end><wait>", "text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
   shutdown_timeout = var.common_shutdown_timeout

--- a/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
@@ -76,7 +76,7 @@ source "vsphere-iso" "linux-centos-stream" {
   }
   boot_order       = var.vm_boot_order
   boot_wait        = var.vm_boot_wait
-  boot_command     = ["up", "e", "<down><down><end><wait>", "text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
+  boot_command     = ["up", "e", "<down><down><end><wait>", "text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
   shutdown_timeout = var.common_shutdown_timeout

--- a/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
+++ b/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
@@ -76,7 +76,7 @@ source "vsphere-iso" "linux-redhat-linux" {
   }
   boot_order       = var.vm_boot_order
   boot_wait        = var.vm_boot_wait
-  boot_command     = ["up", "e", "<down><down><end><wait>", "text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
+  boot_command     = ["up", "e", "<down><down><end><wait>", "text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
   shutdown_timeout = var.common_shutdown_timeout

--- a/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
+++ b/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
@@ -76,7 +76,7 @@ source "vsphere-iso" "linux-rocky-linux" {
   }
   boot_order       = var.vm_boot_order
   boot_wait        = var.vm_boot_wait
-  boot_command     = ["up", "e", "<down><down><end><wait>", "text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
+  boot_command     = ["up", "e", "<down><down><end><wait>", "text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg", "<enter><wait><leftCtrlOn>x<leftCtrlOff>"]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
   shutdown_timeout = var.common_shutdown_timeout


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

<!-- 
    Please provide a clear and concise description of the pull request.
-->

Updated the `boot_command` for rhel/variants to use `inst.ks=` instead of `ks=`.

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [X] This is a refactoring update.
- [X] This is something else.
      Please describe: Replacing deprecated `ks=` command.

**Context of the Pull Request***

<!-- 
    Please describe the current behavior that you are modifying or link to a relevant issue. 
-->

Updated the `boot_command` for rhel/variants to use `inst.ks=` instead of `ks=`.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
