### PR TITLE
[WIP] Add configurable data source provisioning for Linux images

### DIFF
--- a/builds/common.pkrvars.hcl
+++ b/builds/common.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Common variables used for all builds.
     - Variables are use by the source blocks.
 */
@@ -21,6 +21,7 @@ common_iso_path      = "iso"
 common_iso_hash      = "sha512"
 
 // Boot and Provisioning Settings
+common_data_source      = "http"
 common_http_port_min    = 8000
 common_http_port_max    = 8099
 common_ip_wait_timeout  = "20m"

--- a/builds/linux/almalinux-8/variables.pkr.hcl
+++ b/builds/linux/almalinux-8/variables.pkr.hcl
@@ -237,6 +237,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/centos-linux-8/variables.pkr.hcl
+++ b/builds/linux/centos-linux-8/variables.pkr.hcl
@@ -237,6 +237,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/centos-stream-8/variables.pkr.hcl
+++ b/builds/linux/centos-stream-8/variables.pkr.hcl
@@ -237,6 +237,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/photon-4/variables.pkr.hcl
+++ b/builds/linux/photon-4/variables.pkr.hcl
@@ -219,6 +219,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/redhat-linux-8/variables.pkr.hcl
+++ b/builds/linux/redhat-linux-8/variables.pkr.hcl
@@ -251,6 +251,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/rocky-linux-8/variables.pkr.hcl
+++ b/builds/linux/rocky-linux-8/variables.pkr.hcl
@@ -237,6 +237,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/ubuntu-server-18-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/variables.pkr.hcl
@@ -237,6 +237,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
@@ -237,6 +237,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/windows/windows-server-2016/variables.pkr.hcl
+++ b/builds/windows/windows-server-2016/variables.pkr.hcl
@@ -261,6 +261,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/windows/windows-server-2019/variables.pkr.hcl
+++ b/builds/windows/windows-server-2019/variables.pkr.hcl
@@ -261,6 +261,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/windows/windows-server-2022/variables.pkr.hcl
+++ b/builds/windows/windows-server-2022/variables.pkr.hcl
@@ -261,6 +261,11 @@ variable "iso_checksum" {
 
 // Boot Settings
 
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'cd')."
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Add configurable data source provisioning to support either HTTP server or CD for Linux images.

- [X] Add `common_data_source` variable 
- [ ] Implement `almalinux-8` target
- [ ] Implement `centos-linux-8` target
- [ ] Implement `centos-stream-8` target
- [ ] Implement `photon-4` target
- [ ] Implement `redhat-linux-8` target
- [ ] Implement `rocky-linux-8` target
- [ ] Implement `ubuntu-server-18-04-lts` target
- [ ] Implement `ubuntu-server-20-04-lts` target

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

See discussion #52

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
