### PR TITLE
Revert to ens33 for Ubuntu 20.04 LTS

### DIFF
--- a/builds/linux/ubuntu-server-20-04-lts/http/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/http/user-data.pkrtpl.hcl
@@ -18,7 +18,7 @@ autoinstall:
     network:
       version: 2
       ethernets:
-        ens192:
+        ens33:
           dhcp4: true
   ssh:
     install-server: true


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Reverting `ens192` to `ens33` from  PR #53 to address #56.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

The use of ens192 is causing IPs to change mid-build. Reverting to `ens33` to resolve the issue in `main`.  We can research more if `ens192` is required.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #56 
Closes: #56 

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
