### PR TITLE
Update PhotonOS to `efi-secure`

### DIFF
--- a/builds/linux/photon-4/data/ks.pkrtpl.hcl
+++ b/builds/linux/photon-4/data/ks.pkrtpl.hcl
@@ -6,7 +6,7 @@
             "text": "${build_password_encrypted}"
         },
     "disk": "/dev/sda",
-    "bootmode": "bios",
+    "bootmode": "efi",
     "packagelist_file": "packages_minimal.json",
     "additional_packages": [
         "sudo",

--- a/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
+++ b/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
@@ -13,7 +13,7 @@ vm_guest_os_version = "4"
 vm_guest_os_type = "vmwarePhoton64Guest"
 
 // Virtual Machine Hardware Settings
-vm_firmware              = "bios"
+vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
 vm_cpu_sockets           = 2
 vm_cpu_cores             = 1

--- a/builds/linux/photon-4/linux-photon.pkr.hcl
+++ b/builds/linux/photon-4/linux-photon.pkr.hcl
@@ -76,9 +76,16 @@ source "vsphere-iso" "linux-photon" {
     "/ks.json"       = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted })
     "/packages.json" = file("${path.cwd}/data/packages_minimal.json")
   }
-  boot_order       = var.vm_boot_order
-  boot_wait        = var.vm_boot_wait
-  boot_command     = ["<esc><wait> vmlinuz initrd=initrd.img root=/dev/ram0 loglevel=3 insecure_installation=1 ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.json photon.media=cdrom <enter>"]
+  boot_order = var.vm_boot_order
+  boot_wait  = var.vm_boot_wait
+  boot_command = [
+    "<esc><wait>c",
+    "linux /isolinux/vmlinuz root=/dev/ram0 loglevel=3 insecure_installation=1 ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.json photon.media=cdrom",
+    "<enter>", "initrd /isolinux/initrd.img",
+    "<enter>",
+    "boot",
+    "<enter>"
+  ]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
   shutdown_timeout = var.common_shutdown_timeout


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Update PhotonOS to `efi-secure`

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Update `bootmode` to `efi`
- Update `vm_firmware` to `efi-secure`
- Update `boot_command`

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [X] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
