### PR TITLE
Allow Packer to be launched from any directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,22 +474,23 @@ For example, if you simply want to build a Microsoft Windows Server 2022 Standar
 
 Initialize the plugins:
 ```
-rainpole@macos packer-examples> cd builds/windows/windows-server-2022/
-rainpole@macos packer-examples> packer init windows-server-2022.pkr.hcl
+rainpole@macos packer-examples> packer init builds/windows/windows-server-2022
 ```
 Build a specific machine image:
 ```
 rainpole@macos windows-server-2022> packer build -force \
       --only vsphere-iso.windows-server-standard-core \
-      -var-file="../../vsphere.pkrvars.hcl" \
-      -var-file="../../build.pkrvars.hcl" \
-      -var-file="../../common.pkrvars.hcl" .
+      -var-file="config/vsphere.pkrvars.hcl" \
+      -var-file="config/build.pkrvars.hcl" \
+      -var-file="config/common.pkrvars.hcl" \
+      builds/windows/windows-server-2022
 ```
 Build a specific machine image using environmental variables:
 ```
 rainpole@macos windows-server-2022> packer build -force \
       --only vsphere-iso.windows-server-standard-core \
-      -var-file="../../common.pkrvars.hcl" .
+      -var-file="config/common.pkrvars.hcl" \
+      builds/windows/windows-server-2022
 ```
 Happy building!!!
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ SCRIPT_PATH=$(realpath "$(dirname "$(follow_link "$0")")")
 CONFIG_PATH=$(realpath "${1:-${SCRIPT_PATH}/config}")
 
 menu_option_1() {
-  cd "$SCRIPT_PATH"/builds/linux/photon-4/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/photon-4/
   echo -e "\nCONFIRM: Build a VMware Photon OS 4 Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -29,7 +29,7 @@ menu_option_1() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Applying the HashiCorp Packer Build ..."
@@ -38,14 +38,15 @@ menu_option_1() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_2() {
-  cd "$SCRIPT_PATH"/builds/linux/ubuntu-server-20-04-lts/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/ubuntu-server-20-04-lts/
   echo -e "\nCONFIRM: Build a Ubuntu Server 20.04 LTS Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -59,7 +60,7 @@ menu_option_2() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Applying the HashiCorp Packer Build ..."
@@ -68,14 +69,15 @@ menu_option_2() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_3() {
-  cd "$SCRIPT_PATH"/builds/linux/ubuntu-server-18-04-lts/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/ubuntu-server-18-04-lts/
   echo -e "\nCONFIRM: Build a Ubuntu Server 18.04 LTS Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -89,7 +91,7 @@ menu_option_3() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Applying the HashiCorp Packer Build ..."
@@ -98,14 +100,15 @@ menu_option_3() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_4() {
-  cd "$SCRIPT_PATH"/builds/linux/redhat-linux-8/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/redhat-linux-8/
   echo -e "\nCONFIRM: Build a Red Hat Enerprise Linux 8 Server Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -119,7 +122,7 @@ menu_option_4() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Applying the HashiCorp Packer Build ..."
@@ -129,14 +132,15 @@ menu_option_4() {
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/rhsm.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/rhsm.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_5() {
-  cd "$SCRIPT_PATH"/builds/linux/almalinux-8/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/almalinux-8/
   echo -e "\nCONFIRM: Build an AlmaLinux 8 Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -150,7 +154,7 @@ menu_option_5() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -159,14 +163,15 @@ menu_option_5() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_6() {
-  cd "$SCRIPT_PATH"/builds/linux/rocky-linux-8/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/rocky-linux-8/
   echo -e "\nCONFIRM: Build a Rocky Linux 8 Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -180,7 +185,7 @@ menu_option_6() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -189,14 +194,15 @@ menu_option_6() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_7() {
-  cd "$SCRIPT_PATH"/builds/linux/centos-stream-8/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/centos-stream-8/
   echo -e "\nCONFIRM: Build a CentOS Stream 8 Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -207,7 +213,7 @@ menu_option_7() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -216,14 +222,15 @@ menu_option_7() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_8() {
-  cd "$SCRIPT_PATH"/builds/linux/centos-linux-8/
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/centos-linux-8/
   echo -e "\nCONFIRM: Build a CentOS Linux 8 Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -237,7 +244,7 @@ menu_option_8() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -246,14 +253,15 @@ menu_option_8() {
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/proxy.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_9() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2022/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2022/
   echo -e "\nCONFIRM: Build all Microsoft Windows Server 2022 Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -267,21 +275,22 @@ menu_option_9() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
   packer build -force \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_10() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2022/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2022/
   echo -e "\nCONFIRM: Build Microsoft Windows Server 2022 Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -295,7 +304,7 @@ menu_option_10() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -303,14 +312,15 @@ menu_option_10() {
       --only vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_11() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2022/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2022/
   echo -e "\nCONFIRM: Build Microsoft Windows Server 2022 Datacenter Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -324,7 +334,7 @@ menu_option_11() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -332,14 +342,15 @@ menu_option_11() {
       --only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_12() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2019/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2019/
   echo -e "\nCONFIRM: Build all Microsoft Windows Server 2019 Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -353,21 +364,22 @@ menu_option_12() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
   packer build -force \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_13() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2019/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2019/
   echo -e "\nCONFIRM: Build Microsoft Windows Server 2019 Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -381,7 +393,7 @@ menu_option_13() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -389,14 +401,15 @@ menu_option_13() {
       --only vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_14() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2019/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2019/
   echo -e "\nCONFIRM: Build Microsoft Windows Server 2019 Datacenter Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -410,7 +423,7 @@ menu_option_14() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -418,14 +431,15 @@ menu_option_14() {
       --only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_15() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2016/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2016/
   echo -e "\nCONFIRM: Build all Microsoft Windows Server 2016 Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -439,21 +453,22 @@ menu_option_15() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
   packer build -force \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_16() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2016/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2016/
   echo -e "\nCONFIRM: Build Microsoft Windows Server 2016 Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -467,7 +482,7 @@ menu_option_16() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -475,14 +490,15 @@ menu_option_16() {
       --only vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."
 }
 
 menu_option_17() {
-  cd "$SCRIPT_PATH"/builds/windows/windows-server-2016/
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-server-2016/
   echo -e "\nCONFIRM: Build Microsoft Windows Server 2016 Datacenter Templates for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
@@ -496,7 +512,7 @@ menu_option_17() {
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
-  packer init .
+  packer init "$INPUT_PATH"
 
   ### Apply the HashiCorp Packer Build ###
   echo "Starting the HashiCorp Packer build ..."
@@ -504,7 +520,8 @@ menu_option_17() {
       --only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core \
       -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
       -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
-      -var-file="$CONFIG_PATH/common.pkrvars.hcl" .
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
 
   ### All done. ###
   echo "Done."

--- a/builds/linux/almalinux-8/linux-almalinux.auto.pkrvars.hcl
+++ b/builds/linux/almalinux-8/linux-almalinux.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     AlmaLinux 8 variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/redhat-variant.sh"]
+scripts = ["scripts/linux/redhat-variant.sh"]
 inline  = []

--- a/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
@@ -21,9 +21,9 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
   data_source_content = {
-    "/ks.cfg" = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 }
@@ -118,7 +118,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -129,7 +129,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/centos-linux-8/linux-centos-linux.auto.pkrvars.hcl
+++ b/builds/linux/centos-linux-8/linux-centos-linux.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     CentOS Linux 8 variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/redhat-variant.sh"]
+scripts = ["scripts/linux/redhat-variant.sh"]
 inline  = []

--- a/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
+++ b/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
@@ -21,9 +21,9 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
   data_source_content = {
-    "/ks.cfg" = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 }
@@ -118,7 +118,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -129,7 +129,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/centos-stream-8/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos-stream-8/linux-centos-stream.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     CentOS Stream 8 variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/redhat-variant.sh"]
+scripts = ["scripts/linux/redhat-variant.sh"]
 inline  = []

--- a/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
@@ -21,9 +21,9 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
   data_source_content = {
-    "/ks.cfg" = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 }
@@ -118,7 +118,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -129,7 +129,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
+++ b/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     VMware Photon OS 4 variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -38,5 +38,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/photon.sh"]
+scripts = ["scripts/linux/photon.sh"]
 inline  = []

--- a/builds/linux/photon-4/linux-photon.pkr.hcl
+++ b/builds/linux/photon-4/linux-photon.pkr.hcl
@@ -21,7 +21,7 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
 }
 
 //  BLOCK: source
@@ -73,8 +73,8 @@ source "vsphere-iso" "linux-photon" {
   http_port_min = var.common_http_port_min
   http_port_max = var.common_http_port_max
   http_content = {
-    "/ks.json"       = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted })
-    "/packages.json" = file("${path.cwd}/data/packages_minimal.json")
+    "/ks.json"       = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted })
+    "/packages.json" = file("${abspath(path.root)}/data/packages_minimal.json")
   }
   boot_order = var.vm_boot_order
   boot_wait  = var.vm_boot_wait
@@ -121,7 +121,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -132,7 +132,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/redhat-linux-8/linux-redhat-linux.auto.pkrvars.hcl
+++ b/builds/linux/redhat-linux-8/linux-redhat-linux.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Red Hat Enterprise Linux 8 variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/redhat-linux.sh"]
+scripts = ["scripts/linux/redhat-linux.sh"]
 inline  = []

--- a/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
+++ b/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
@@ -21,9 +21,9 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
   data_source_content = {
-    "/ks.cfg" = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 }
@@ -118,7 +118,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -131,7 +131,7 @@ build {
       "RHSM_USERNAME=${var.rhsm_username}",
       "RHSM_PASSWORD=${var.rhsm_password}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/rocky-linux-8/linux-rocky-linux.auto.pkrvars.hcl
+++ b/builds/linux/rocky-linux-8/linux-rocky-linux.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Rocky Linux 8 variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/redhat-variant.sh"]
+scripts = ["scripts/linux/redhat-variant.sh"]
 inline  = []

--- a/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
+++ b/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
@@ -21,9 +21,9 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
   data_source_content = {
-    "/ks.cfg" = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 }
@@ -118,7 +118,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -129,7 +129,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Ubuntu Server 18.04 LTS variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/ubuntu-server-18.sh"]
+scripts = ["scripts/linux/ubuntu-server-18.sh"]
 inline  = []

--- a/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.pkr.hcl
@@ -21,7 +21,7 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
 }
 
 //  BLOCK: source
@@ -73,7 +73,7 @@ source "vsphere-iso" "linux-ubuntu-server" {
   http_port_min = var.common_http_port_min
   http_port_max = var.common_http_port_max
   http_content = {
-    "/ks.cfg" = templatefile("${path.cwd}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   boot_order = var.vm_boot_order
   boot_wait  = var.vm_boot_wait
@@ -126,7 +126,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -137,7 +137,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Ubuntu Server 20.04 LTS  variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -41,5 +41,5 @@ communicator_port    = 22
 communicator_timeout = "30m"
 
 // Provisioner Settings
-scripts = ["../../../scripts/linux/ubuntu-server-2x.sh"]
+scripts = ["scripts/linux/ubuntu-server-2x.sh"]
 inline  = []

--- a/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
@@ -21,10 +21,10 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
   data_source_content = {
-    "/meta-data" = file("${path.cwd}/data/meta-data")
-    "/user-data" = templatefile("${path.cwd}/data/user-data.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "/meta-data" = file("${abspath(path.root)}/data/meta-data")
+    "/user-data" = templatefile("${abspath(path.root)}/data/user-data.pkrtpl.hcl", { build_username = var.build_username, build_password_encrypted = var.build_password_encrypted, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
   data_source_command = var.common_data_source == "http" ? "ds=nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/" : "ds=nocloud"
 }
@@ -120,7 +120,7 @@ build {
 
   provisioner "file" {
     destination = "/tmp/root-ca.crt"
-    source      = "../../../certificates/root-ca.crt"
+    source      = "${path.cwd}/certificates/root-ca.crt"
   }
 
   provisioner "shell" {
@@ -131,7 +131,7 @@ build {
       "ANSIBLE_USERNAME=${var.ansible_username}",
       "ANSIBLE_KEY=${var.ansible_key}"
     ]
-    scripts = var.scripts
+    scripts = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   post-processor "manifest" {

--- a/builds/windows/windows-server-2016/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/windows-server-2016/windows-server.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Microsoft Windows Server 2016 Standard variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -47,9 +47,7 @@ communicator_port    = 5985
 communicator_timeout = "12h"
 
 // Provisioner Settings
-scripts = [
-  "../../../scripts/windows/windows-server-prepare.ps1"
-]
+scripts = [ "scripts/windows/windows-server-prepare.ps1" ]
 inline = [
   "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
   "choco feature enable -n allowGlobalConfirmation",

--- a/builds/windows/windows-server-2016/windows-server.pkr.hcl
+++ b/builds/windows/windows-server-2016/windows-server.pkr.hcl
@@ -27,7 +27,7 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
 }
 
 //  BLOCK: source
@@ -75,11 +75,11 @@ source "vsphere-iso" "windows-server-standard-core" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERSTANDARDCORE", kms_key = "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERSTANDARDCORE", kms_key = "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -153,11 +153,11 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERSTANDARD", kms_key = "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERSTANDARD", kms_key = "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -232,11 +232,11 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERDATACENTERCORE", kms_key = "CB7KF-BWN84-R7R2Y-793K2-8XDDG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERDATACENTERCORE", kms_key = "CB7KF-BWN84-R7R2Y-793K2-8XDDG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -311,11 +311,11 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERDATACENTER", kms_key = "CB7KF-BWN84-R7R2Y-793K2-8XDDG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2016 SERVERDATACENTER", kms_key = "CB7KF-BWN84-R7R2Y-793K2-8XDDG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -359,7 +359,7 @@ build {
   ]
 
   provisioner "file" {
-    source      = "../../../certificates/root-ca.p7b"
+    source      = "${path.cwd}/certificates/root-ca.p7b"
     destination = "C:\\windows\\temp\\root-ca.p7b"
   }
 
@@ -369,7 +369,7 @@ build {
     ]
     elevated_user     = var.build_username
     elevated_password = var.build_password
-    scripts           = var.scripts
+    scripts           = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   provisioner "powershell" {

--- a/builds/windows/windows-server-2019/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/windows-server-2019/windows-server.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Microsoft Windows Server 2019 Standard variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -47,9 +47,7 @@ communicator_port    = 5985
 communicator_timeout = "12h"
 
 // Provisioner Settings
-scripts = [
-  "../../../scripts/windows/windows-server-prepare.ps1"
-]
+scripts = [ "scripts/windows/windows-server-prepare.ps1" ]
 inline = [
   "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
   "choco feature enable -n allowGlobalConfirmation",

--- a/builds/windows/windows-server-2019/windows-server.pkr.hcl
+++ b/builds/windows/windows-server-2019/windows-server.pkr.hcl
@@ -27,7 +27,7 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
 }
 
 //  BLOCK: source
@@ -75,11 +75,11 @@ source "vsphere-iso" "windows-server-standard-core" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERSTANDARDCORE", kms_key = "N69G4-B89J2-4G8F4-WWYCC-J464C", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERSTANDARDCORE", kms_key = "N69G4-B89J2-4G8F4-WWYCC-J464C", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -154,11 +154,11 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERSTANDARD", kms_key = "N69G4-B89J2-4G8F4-WWYCC-J464C", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERSTANDARD", kms_key = "N69G4-B89J2-4G8F4-WWYCC-J464C", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -233,11 +233,11 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERDATACENTERCORE", kms_key = "WMDGN-G9PQG-XVVXX-R3X43-63DFG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERDATACENTERCORE", kms_key = "WMDGN-G9PQG-XVVXX-R3X43-63DFG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -312,11 +312,11 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERDATACENTER", kms_key = "WMDGN-G9PQG-XVVXX-R3X43-63DFG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2019 SERVERDATACENTER", kms_key = "WMDGN-G9PQG-XVVXX-R3X43-63DFG", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -360,7 +360,7 @@ build {
   ]
 
   provisioner "file" {
-    source      = "../../../certificates/root-ca.p7b"
+    source      = "${path.cwd}/certificates/root-ca.p7b"
     destination = "C:\\windows\\temp\\root-ca.p7b"
   }
 
@@ -370,7 +370,7 @@ build {
     ]
     elevated_user     = var.build_username
     elevated_password = var.build_password
-    scripts           = var.scripts
+    scripts           = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   provisioner "powershell" {

--- a/builds/windows/windows-server-2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/windows-server-2022/windows-server.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 /*
-    DESCRIPTION: 
+    DESCRIPTION:
     Microsoft Windows Server 2022 Standard variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
@@ -47,9 +47,7 @@ communicator_port    = 5985
 communicator_timeout = "12h"
 
 // Provisioner Settings
-scripts = [
-  "../../../scripts/windows/windows-server-prepare.ps1"
-]
+scripts = [ "scripts/windows/windows-server-prepare.ps1" ]
 inline = [
   "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
   "choco feature enable -n allowGlobalConfirmation",

--- a/builds/windows/windows-server-2022/windows-server.pkr.hcl
+++ b/builds/windows/windows-server-2022/windows-server.pkr.hcl
@@ -27,7 +27,7 @@ packer {
 
 locals {
   buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  path_manifest = "../../../manifests/"
+  path_manifest = "${path.cwd}/manifests/"
 }
 
 //  BLOCK: source
@@ -75,11 +75,11 @@ source "vsphere-iso" "windows-server-standard-core" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERSTANDARDCORE", kms_key = "VDYBN-27WPP-V4HQT-9VMD4-VMK7H", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERSTANDARDCORE", kms_key = "VDYBN-27WPP-V4HQT-9VMD4-VMK7H", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -154,11 +154,11 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERSTANDARD", kms_key = "VDYBN-27WPP-V4HQT-9VMD4-VMK7H", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERSTANDARD", kms_key = "VDYBN-27WPP-V4HQT-9VMD4-VMK7H", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -233,11 +233,11 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERDATACENTERCORE", kms_key = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERDATACENTERCORE", kms_key = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -312,11 +312,11 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
-    "../../../scripts/${var.vm_guest_os_family}/",
-    "../../../certificates/"
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
   ]
   cd_content = {
-    "autounattend.xml" = templatefile("${path.cwd}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERDATACENTER", kms_key = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", { os_image = "Windows Server 2022 SERVERDATACENTER", kms_key = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33", build_username = var.build_username, build_password = var.build_password, vm_guest_os_language = var.vm_guest_os_language, vm_guest_os_keyboard = var.vm_guest_os_keyboard, vm_guest_os_timezone = var.vm_guest_os_timezone })
   }
 
   // Boot and Provisioning Settings
@@ -360,7 +360,7 @@ build {
   ]
 
   provisioner "file" {
-    source      = "../../../certificates/root-ca.p7b"
+    source      = "${path.cwd}/certificates/root-ca.p7b"
     destination = "C:\\windows\\temp\\root-ca.p7b"
   }
 
@@ -370,7 +370,7 @@ build {
     ]
     elevated_user     = var.build_username
     elevated_password = var.build_password
-    scripts           = var.scripts
+    scripts           = formatlist("${path.cwd}/%s", var.scripts)
   }
 
   provisioner "powershell" {


### PR DESCRIPTION
**Summary of Pull Request**

Use the flexibiliy of `path.cwd` and `path.root` when using `build.sh`.
See https://www.packer.io/docs/templates/hcl_templates/path-variables

Following updates have been done:

- remove `../../..` from everywhere (that ease a refactoring if necessary)
- replace `path.cwd` by `path.root` to access files data directory
- replace `../../certificates` by `${path.cwd}/certificates` to access certificates
- replace `../../manifests` by `${path.cwd}/manifests` to access manifests
- replace `../../scripts` by `${path.cwd}/scripts` to access scripts

So, the `packer` command could be launched from whatever directory that contains custom `certificates`, `scripts` and output `manifests`.

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [x] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

Enable advanced customization of the core behavior from `builds` directory.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [X] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
