### PR TITLE
Add HTTP IP address option

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,31 +270,54 @@ ansible_key      = "<public_key>"
 
 #### **Common Variables**
 
-Edit the `/config/common.pkvars.hcl` file to configure the following:
+Edit the `/config/common.pkvars.hcl` file to configure the following common variables:
 
-* Common Data Source
-* Common Virtual Machine Settings
-* Common Template and Content Library Settings
-* Common Removable Media Settings
-* Common Boot and Provisioning Settings
+* Virtual Machine Settings
+* Template and Content Library Settings
+* Removable Media Settings
+* Boot and Provisioning Settings
 
 Example: `/config/common.pkvars.hcl`
 
 ```
-common_data_source             = "http"
+// Virtual Machine Settings
+common_vm_version           = 19
+common_tools_upgrade_policy = true
+common_remove_cdrom         = true
+
+// Template and Content Library Settings
 common_template_conversion     = false
 common_content_library_name    = "sfo-w01-lib01"
 common_content_library_ovf     = true
 common_content_library_destroy = true
+
+// Removable Media Settings
+common_iso_datastore = "sfo-w01-cl01-ds-nfs01"
+common_iso_path      = "iso"
+common_iso_hash      = "sha512"
+
+// Boot and Provisioning Settings
+common_data_source      = "http"
+common_http_ip          = null
+common_http_port_min    = 8000
+common_http_port_max    = 8099
+common_ip_wait_timeout  = "20m"
+common_shutdown_timeout = "15m"
 ```
 
 `http` is the default provisioning data source for Linux machine image builds.
 
-You change the `common_data_source` from `http` to `disk` to build supported Linux machine images without the need to user Packer's HTTP server. This is useful for environments that may not be able to route back to the system from which Packer is running. Currently, the only `cd_content` is used when selecting `disk`.
+You can change the `common_data_source` from `http` to `disk` to build supported Linux machine images without the need to user Packer's HTTP server. This is useful for environments that may not be able to route back to the system from which Packer is running. Currently, the only `cd_content` is used when selecting `disk`.
 
 > Note: The following Linux distributions do not support kickstart from a secondary CD-ROM.
 > - VMware PhotonOS 4
 > - Ubuntu Server 18.04 LTS
+
+If you need to define a specific IPv4 address from your host for Packer's HTTP Server, modify the `common_http_ip` variable from `null` to a `string` value. For example:
+
+```
+common_http_ip = "172.16.11.254"
+```
 
 #### **Proxy Variables**
 

--- a/builds/common.pkrvars.hcl.example
+++ b/builds/common.pkrvars.hcl.example
@@ -22,6 +22,7 @@ common_iso_hash      = "sha512"
 
 // Boot and Provisioning Settings
 common_data_source      = "http"
+common_http_ip          = null
 common_http_port_min    = 8000
 common_http_port_max    = 8099
 common_ip_wait_timeout  = "20m"

--- a/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
@@ -74,6 +74,7 @@ source "vsphere-iso" "linux-almalinux" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
   http_port_min = var.common_data_source == "http" ? var.common_http_port_min : null
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   http_content  = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/almalinux-8/variables.pkr.hcl
+++ b/builds/linux/almalinux-8/variables.pkr.hcl
@@ -242,6 +242,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
+++ b/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
@@ -74,6 +74,7 @@ source "vsphere-iso" "linux-centos-linux" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
   http_port_min = var.common_data_source == "http" ? var.common_http_port_min : null
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   http_content  = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/centos-linux-8/variables.pkr.hcl
+++ b/builds/linux/centos-linux-8/variables.pkr.hcl
@@ -242,6 +242,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
@@ -74,6 +74,7 @@ source "vsphere-iso" "linux-centos-stream" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
   http_port_min = var.common_data_source == "http" ? var.common_http_port_min : null
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   http_content  = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/centos-stream-8/variables.pkr.hcl
+++ b/builds/linux/centos-stream-8/variables.pkr.hcl
@@ -242,6 +242,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/photon-4/linux-photon.pkr.hcl
+++ b/builds/linux/photon-4/linux-photon.pkr.hcl
@@ -70,6 +70,7 @@ source "vsphere-iso" "linux-photon" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_http_ip
   http_port_min = var.common_http_port_min
   http_port_max = var.common_http_port_max
   http_content = {

--- a/builds/linux/photon-4/variables.pkr.hcl
+++ b/builds/linux/photon-4/variables.pkr.hcl
@@ -224,6 +224,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
+++ b/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
@@ -74,6 +74,7 @@ source "vsphere-iso" "linux-redhat-linux" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
   http_port_min = var.common_data_source == "http" ? var.common_http_port_min : null
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   http_content  = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/redhat-linux-8/variables.pkr.hcl
+++ b/builds/linux/redhat-linux-8/variables.pkr.hcl
@@ -256,6 +256,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
+++ b/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
@@ -74,6 +74,7 @@ source "vsphere-iso" "linux-rocky-linux" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
   http_port_min = var.common_data_source == "http" ? var.common_http_port_min : null
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   http_content  = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/rocky-linux-8/variables.pkr.hcl
+++ b/builds/linux/rocky-linux-8/variables.pkr.hcl
@@ -242,6 +242,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.pkr.hcl
@@ -70,6 +70,7 @@ source "vsphere-iso" "linux-ubuntu-server" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_http_ip
   http_port_min = var.common_http_port_min
   http_port_max = var.common_http_port_max
   http_content = {

--- a/builds/linux/ubuntu-server-18-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/variables.pkr.hcl
@@ -242,6 +242,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."

--- a/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
@@ -75,6 +75,7 @@ source "vsphere-iso" "linux-ubuntu-server" {
   iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
 
   // Boot and Provisioning Settings
+  http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
   http_port_min = var.common_data_source == "http" ? var.common_http_port_min : null
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   http_content  = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
@@ -242,6 +242,12 @@ variable "common_data_source" {
   description = "The provisioning data source ('http' or 'disk')."
 }
 
+variable "common_http_ip" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
 variable "common_http_port_min" {
   type        = number
   description = "The start of the HTTP port range."


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Adds the option define a specific IPv4 address from your host for Packer's HTTP Server.

Modify the `common_http_ip `variable from `null` to a `string` value. 

For example: `common_http_ip = "172.16.11.254"`

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [X] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Adds `common_http_ip` to `common.pkrvars.hcl.example`. Default, `null`.
- Adds `common_http_ip` to `variables.pkr.hcl' for Linux distributions.
- Adds `http_ip` to the`*.pkr.hcl` for Linux distributions.
- Updates the project documentation for `common.pkrvars.hcl` settings.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #49 
Closes: #49 

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [X] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
