### PR TITLE
Add Windows 10 Professional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following builds are available:
 * Microsoft Windows Server 2022 - Standard and Datacenter
 * Microsoft Windows Server 2019 - Standard and Datacenter
 * Microsoft Windows Server 2016 - Standard and Datacenter
-* Microsoft Windows 10 Pro
+* Microsoft Windows 10 Professional
 
 > **NOTE**: Guest customization is [**not supported**](https://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf) for AlmaLinux and Rocky Linux in vCenter Server 7.0 Update 2. 
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Example: Menu for `./build.sh`.
         15  -  Windows Server 2016 - All
         16  -  Windows Server 2016 - Standard Only
         17  -  Windows Server 2016 - Datacenter Only
-        18  -  Windows 10 Pro
+        18  -  Windows 10 Professional
 
       Other:
       

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following builds are available:
 * Microsoft Windows Server 2022 - Standard and Datacenter
 * Microsoft Windows Server 2019 - Standard and Datacenter
 * Microsoft Windows Server 2016 - Standard and Datacenter
+* Microsoft Windows 10 Pro
 
 > **NOTE**: Guest customization is [**not supported**](https://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf) for AlmaLinux and Rocky Linux in vCenter Server 7.0 Update 2. 
 
@@ -153,6 +154,7 @@ The files are distributed in the following directories.
     * Microsoft Windows Server 2022
     * Microsoft Windows Server 2019
     * Microsoft Windows Server 2016
+    * Microsoft Windows 10
 
 2. Rename your guest operating system `.iso` images. The examples in this repository _generally_ use the format of `iso-family-vendor-type-version.iso`. 
 
@@ -485,6 +487,7 @@ Example: Menu for `./build.sh`.
         15  -  Windows Server 2016 - All
         16  -  Windows Server 2016 - Standard Only
         17  -  Windows Server 2016 - Datacenter Only
+        18  -  Windows 10 Pro
 
       Other:
       

--- a/build.sh
+++ b/build.sh
@@ -532,6 +532,35 @@ menu_option_17() {
   echo "Done."
 }
 
+menu_option_18() {
+  INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-10/
+  echo -e "\nCONFIRM: Build Microsoft Windows 10 Pro Template for VMware vSphere."
+  echo -e "\nContinue? (y/n)"
+  read -r REPLY
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    exit 1
+  fi
+
+  ### Build Microsoft Windows Server 2016 Datacenter Templates for VMware vSphere ###
+  echo "Building a Microsoft Microsoft Windows 10 Pro Template for VMware vSphere  ..."
+
+  ### Initialize Hashicorp Packer and required plugins ###
+  echo "Initializing Hashicorp Packer and required plugins ..."
+  packer init "$INPUT_PATH"
+
+  ### Apply the HashiCorp Packer Build ###
+  echo "Starting the HashiCorp Packer build ..."
+  packer build -force \
+      -var-file="$CONFIG_PATH/vsphere.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      "$INPUT_PATH"
+
+  ### All done. ###
+  echo "Done."
+}
+
 press_enter() {
   cd "$SCRIPT_PATH"
   echo -n "Press Enter to continue."
@@ -590,6 +619,7 @@ until [ "$selection" = "0" ]; do
   echo "    	15  -  Windows Server 2016 - All"
   echo "    	16  -  Windows Server 2016 - Standard Only"
   echo "    	17  -  Windows Server 2016 - Datacenter Only"
+  echo "    	18  -  Windows 10 Pro"
   echo ""
   echo "      Other:"
   echo ""
@@ -616,6 +646,7 @@ until [ "$selection" = "0" ]; do
     15 ) clear ; menu_option_15 ; press_enter ;;
     16 ) clear ; menu_option_16 ; press_enter ;;
     17 ) clear ; menu_option_17 ; press_enter ;;
+    18 ) clear ; menu_option_18 ; press_enter ;;
     I ) clear ; info ; press_enter ;;
     Q ) clear ; exit ;;
     * ) clear ; incorrect_selection ; press_enter ;;

--- a/build.sh
+++ b/build.sh
@@ -534,7 +534,7 @@ menu_option_17() {
 
 menu_option_18() {
   INPUT_PATH="$SCRIPT_PATH"/builds/windows/windows-10/
-  echo -e "\nCONFIRM: Build Microsoft Windows 10 Pro Template for VMware vSphere."
+  echo -e "\nCONFIRM: Build Microsoft Windows 10 Professional Template for VMware vSphere."
   echo -e "\nContinue? (y/n)"
   read -r REPLY
   if [[ ! $REPLY =~ ^[Yy]$ ]]
@@ -542,8 +542,8 @@ menu_option_18() {
     exit 1
   fi
 
-  ### Build Microsoft Windows Server 2016 Datacenter Templates for VMware vSphere ###
-  echo "Building a Microsoft Microsoft Windows 10 Pro Template for VMware vSphere  ..."
+  ### Build Microsoft Windows 10 Professional for VMware vSphere ###
+  echo "Building a Microsoft Microsoft Windows 10 Professional Template for VMware vSphere  ..."
 
   ### Initialize Hashicorp Packer and required plugins ###
   echo "Initializing Hashicorp Packer and required plugins ..."
@@ -573,7 +573,7 @@ info() {
   echo "License: Apache License Version 2.0."
   echo ""
   echo "Versions Used:"
-  echo "HashiCorp Packer >= 1.7.4."
+  echo "HashiCorp Packer >= 1.7.6."
   echo "HashiCorp Packer Plugin for VMware vSphere >= 1.0.1"
   echo "HashiCorp Packer Plugin for Windows Update >= 0.14.0"
   echo ""
@@ -619,7 +619,7 @@ until [ "$selection" = "0" ]; do
   echo "    	15  -  Windows Server 2016 - All"
   echo "    	16  -  Windows Server 2016 - Standard Only"
   echo "    	17  -  Windows Server 2016 - Datacenter Only"
-  echo "    	18  -  Windows 10 Pro"
+  echo "    	18  -  Windows 10 Professional"
   echo ""
   echo "      Other:"
   echo ""

--- a/builds/windows/windows-10/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-10/data/autounattend.pkrtpl.hcl
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+   <settings pass="windowsPE">
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <SetupUILanguage>
+            <UILanguage>${vm_inst_os_language}</UILanguage>
+         </SetupUILanguage>
+         <InputLocale>${vm_inst_os_keyboard}</InputLocale>
+         <SystemLocale>${vm_inst_os_language}</SystemLocale>
+         <UILanguage>${vm_inst_os_language}</UILanguage>
+         <UILanguageFallback>${vm_inst_os_language}</UILanguageFallback>
+         <UserLocale>${vm_inst_os_language}</UserLocale>
+      </component>
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <DriverPaths>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+               <Path>E:\Program Files\VMware\VMware Tools\Drivers\pvscsi\Win8\amd64</Path>
+            </PathAndCredentials>
+         </DriverPaths>
+      </component>
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <DiskConfiguration>
+            <Disk wcm:action="add">
+               <DiskID>0</DiskID>
+               <WillWipeDisk>true</WillWipeDisk>
+               <CreatePartitions>
+                  <!-- Windows RE Tools partition -->
+                  <CreatePartition wcm:action="add">
+                     <Order>1</Order>
+                     <Type>Primary</Type>
+                     <Size>300</Size>
+                  </CreatePartition>
+                  <!-- System partition (ESP) -->
+                  <CreatePartition wcm:action="add">
+                     <Order>2</Order>
+                     <Type>EFI</Type>
+                     <Size>100</Size>
+                  </CreatePartition>
+                  <!-- Microsoft reserved partition (MSR) -->
+                  <CreatePartition wcm:action="add">
+                     <Order>3</Order>
+                     <Type>MSR</Type>
+                     <Size>128</Size>
+                  </CreatePartition>
+                  <!-- Windows partition -->
+                  <CreatePartition wcm:action="add">
+                     <Order>4</Order>
+                     <Type>Primary</Type>
+                     <Extend>true</Extend>
+                  </CreatePartition>
+               </CreatePartitions>
+               <ModifyPartitions>
+                  <!-- Windows RE Tools partition -->
+                  <ModifyPartition wcm:action="add">
+                     <Order>1</Order>
+                     <PartitionID>1</PartitionID>
+                     <Label>WINRE</Label>
+                     <Format>NTFS</Format>
+                     <TypeID>DE94BBA4-06D1-4D40-A16A-BFD50179D6AC</TypeID>
+                  </ModifyPartition>
+                  <!-- System partition (ESP) -->
+                  <ModifyPartition wcm:action="add">
+                     <Order>2</Order>
+                     <PartitionID>2</PartitionID>
+                     <Label>System</Label>
+                     <Format>FAT32</Format>
+                  </ModifyPartition>
+                  <!-- MSR partition does not need to be modified -->
+                  <ModifyPartition wcm:action="add">
+                     <Order>3</Order>
+                     <PartitionID>3</PartitionID>
+                  </ModifyPartition>
+                  <!-- Windows partition -->
+                  <ModifyPartition wcm:action="add">
+                     <Order>4</Order>
+                     <PartitionID>4</PartitionID>
+                     <Label>OS</Label>
+                     <Letter>C</Letter>
+                     <Format>NTFS</Format>
+                  </ModifyPartition>
+               </ModifyPartitions>
+            </Disk>
+         </DiskConfiguration>
+         <ImageInstall>
+            <OSImage>
+               <InstallFrom>
+                  <MetaData wcm:action="add">
+                     <Key>/IMAGE/NAME</Key>
+                     <Value>${os_image}</Value>
+                  </MetaData>
+               </InstallFrom>
+               <InstallTo>
+                  <DiskID>0</DiskID>
+                  <PartitionID>4</PartitionID>
+               </InstallTo>
+            </OSImage>
+         </ImageInstall>
+         <UserData>
+            <AcceptEula>true</AcceptEula>
+            <FullName>${build_username}</FullName>
+            <Organization>${build_username}</Organization>
+            <ProductKey>
+               <Key>${kms_key}</Key>
+               <WillShowUI>OnError</WillShowUI>
+            </ProductKey>
+         </UserData>
+         <EnableFirewall>false</EnableFirewall>
+      </component>
+   </settings>
+   <settings pass="offlineServicing">
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <EnableLUA>false</EnableLUA>
+      </component>
+   </settings>
+   <settings pass="generalize">
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Security-SPP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <SkipRearm>1</SkipRearm>
+      </component>
+   </settings>
+   <settings pass="specialize">
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <OEMInformation>
+            <HelpCustomized>false</HelpCustomized>
+         </OEMInformation>
+         <ComputerName>win-10-pro</ComputerName>
+         <TimeZone>${vm_guest_os_timezone}</TimeZone>
+         <RegisteredOwner />
+      </component>
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+      </component>
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-OutOfBoxExperience" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <DoNotOpenInitialConfigurationTasksAtLogon>true</DoNotOpenInitialConfigurationTasksAtLogon>
+      </component>
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <SkipAutoActivation>true</SkipAutoActivation>
+      </component>
+   </settings>
+   <settings pass="oobeSystem">
+      <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         <InputLocale>${vm_guest_os_keyboard}</InputLocale>
+         <SystemLocale>${vm_guest_os_language}</SystemLocale>
+         <UILanguage>${vm_guest_os_language}</UILanguage>
+         <UILanguageFallback>${vm_guest_os_language}</UILanguageFallback>
+         <UserLocale>${vm_guest_os_language}</UserLocale>
+      </component>
+      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+         <AutoLogon>
+            <Password>
+               <Value>${build_password}</Value>
+               <PlainText>true</PlainText>
+            </Password>
+            <Enabled>true</Enabled>
+            <Username>${build_username}</Username>
+         </AutoLogon>
+         <OOBE>
+            <HideEULAPage>true</HideEULAPage>
+            <HideLocalAccountScreen>true</HideLocalAccountScreen>
+            <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+            <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+            <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+            <NetworkLocation>Work</NetworkLocation>
+            <ProtectYourPC>2</ProtectYourPC>
+         </OOBE>
+         <UserAccounts>
+            <AdministratorPassword>
+               <Value>${build_password}</Value>
+               <PlainText>true</PlainText>
+            </AdministratorPassword>
+            <LocalAccounts>
+               <LocalAccount wcm:action="add">
+                  <Password>
+                     <Value>${build_password}</Value>
+                     <PlainText>true</PlainText>
+                  </Password>
+                  <Group>administrators</Group>
+                  <DisplayName>${build_username}</DisplayName>
+                  <Name>${build_username}</Name>
+                  <Description>Build Account</Description>
+               </LocalAccount>
+            </LocalAccounts>
+         </UserAccounts>
+         <FirstLogonCommands>
+            <SynchronousCommand wcm:action="add">
+               <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+               <Description>Set Execution Policy 64-Bit</Description>
+               <Order>1</Order>
+               <RequiresUserInput>true</RequiresUserInput>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
+               <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+               <Description>Set Execution Policy 32-Bit</Description>
+               <Order>2</Order>
+               <RequiresUserInput>true</RequiresUserInput>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
+               <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -File F:\windows-server-vmtools.ps1</CommandLine>
+               <Order>3</Order>
+               <Description>Install VMware Tools</Description>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
+               <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -File F:\windows-server-init.ps1</CommandLine>
+               <Order>4</Order>
+               <Description>Enable Windows Remote Management</Description>
+            </SynchronousCommand>
+         </FirstLogonCommands>
+      </component>
+   </settings>
+</unattend>

--- a/builds/windows/windows-10/variables.pkr.hcl
+++ b/builds/windows/windows-10/variables.pkr.hcl
@@ -109,7 +109,7 @@ variable "vm_guest_os_version" {
 
 variable "vm_guest_os_type" {
   type        = string
-  description = "The guest operating system type, also know as guestid. (e.g. 'windows2019srv_64Guest')"
+  description = "The guest operating system type, also know as guestid. (e.g. 'windows9_64Guest')"
 }
 
 variable "vm_firmware" {

--- a/builds/windows/windows-10/variables.pkr.hcl
+++ b/builds/windows/windows-10/variables.pkr.hcl
@@ -1,6 +1,6 @@
 /*
     DESCRIPTION:
-    Microsoft Windows 10 Pro Standard variables using the Packer Builder for VMware vSphere (vsphere-iso).
+    Microsoft Windows 10 Professional variables using the Packer Builder for VMware vSphere (vsphere-iso).
 */
 
 //  BLOCK: variable
@@ -104,7 +104,7 @@ variable "vm_guest_os_family" {
 
 variable "vm_guest_os_version" {
   type        = string
-  description = "The guest operating system version. Used for naming. (e.g. '2022')"
+  description = "The guest operating system version. Used for naming. (e.g. '10')"
 }
 
 variable "vm_guest_os_type" {
@@ -236,12 +236,12 @@ variable "common_iso_hash" {
 
 variable "iso_file" {
   type        = string
-  description = "The file name of the ISO image. (e.g. 'iso-windows-server-2019.iso')"
+  description = "The file name of the ISO image. (e.g. 'iso-windows-10.iso')"
 }
 
 variable "iso_checksum" {
   type        = string
-  description = "The checksum of the ISO image. (e.g. Result of 'shasum -a 512 iso-windows-server-2019.iso')"
+  description = "The checksum of the ISO image. (e.g. Result of 'shasum -a 512 iso-windows-10.iso')"
 }
 
 // Boot Settings

--- a/builds/windows/windows-10/variables.pkr.hcl
+++ b/builds/windows/windows-10/variables.pkr.hcl
@@ -1,0 +1,348 @@
+/*
+    DESCRIPTION:
+    Microsoft Windows 10 Pro Standard variables using the Packer Builder for VMware vSphere (vsphere-iso).
+*/
+
+//  BLOCK: variable
+//  Defines the input variables.
+
+// vSphere Credentials
+
+variable "vsphere_endpoint" {
+  type        = string
+  description = "The fully qualified domain name or IP address of the vCenter Server instance. (e.g. 'sfo-w01-vc01.sfo.rainpole.io')"
+}
+
+variable "vsphere_username" {
+  type        = string
+  description = "The username to login to the vCenter Server instance. (e.g. svc-packer-vsphere@rainpole.io)"
+  sensitive   = true
+}
+
+variable "vsphere_password" {
+  type        = string
+  description = "The password for the login to the vCenter Server instance."
+  sensitive   = true
+}
+
+variable "vsphere_insecure_connection" {
+  type        = bool
+  description = "Do not validate vCenter Server TLS certificate."
+  default     = true
+}
+
+// vSphere Settings
+
+variable "vsphere_datacenter" {
+  type        = string
+  description = "The name of the target vSphere datacenter. (e.g. 'sfo-w01-dc01')"
+}
+
+variable "vsphere_cluster" {
+  type        = string
+  description = "The name of the target vSphere cluster. (e.g. 'sfo-w01-cl01')"
+}
+
+variable "vsphere_datastore" {
+  type        = string
+  description = "The name of the target vSphere datastore. (e.g. 'sfo-w01-cl01-vsan01')"
+}
+
+variable "vsphere_network" {
+  type        = string
+  description = "The name of the target vSphere network segment. (e.g. 'sfo-w01-dhcp')"
+}
+
+variable "vsphere_folder" {
+  type        = string
+  description = "The name of the target vSphere cluster. (e.g. 'sfo-w01-fd-templates')"
+}
+
+// Installer Settings
+
+variable "vm_inst_os_language" {
+  type        = string
+  description = "The installation operating system lanugage."
+  default     = "en-GB"
+}
+
+variable "vm_inst_os_keyboard" {
+  type        = string
+  description = "The installation operating system keyboard input."
+  default     = "en-GB"
+}
+
+// Virtual Machine Settings
+
+variable "vm_guest_os_language" {
+  type        = string
+  description = "The guest operating system lanugage."
+  default     = "en-US"
+}
+
+variable "vm_guest_os_keyboard" {
+  type        = string
+  description = "The guest operating system keyboard input."
+  default     = "en-US"
+}
+
+variable "vm_guest_os_timezone" {
+  type        = string
+  description = "The guest operating system timezone."
+  default     = "UTC"
+}
+
+variable "vm_guest_os_vendor" {
+  type        = string
+  description = "The guest operating system vendor. Used for naming . (e.g. 'microsoft)"
+}
+
+variable "vm_guest_os_family" {
+  type        = string
+  description = "The guest operating system family. Used for naming and VMware tools. (e.g.'windows')"
+}
+
+variable "vm_guest_os_version" {
+  type        = string
+  description = "The guest operating system version. Used for naming. (e.g. '2022')"
+}
+
+variable "vm_guest_os_type" {
+  type        = string
+  description = "The guest operating system type, also know as guestid. (e.g. 'windows2019srv_64Guest')"
+}
+
+variable "vm_firmware" {
+  type        = string
+  description = "The virtual machine firmware. (e.g. 'efi-secure'. 'efi', or 'bios')"
+  default     = "efi-secure"
+}
+
+variable "vm_cdrom_type" {
+  type        = string
+  description = "The virtual machine CD-ROM type. (e.g. 'sata', or 'ide')"
+  default     = "sata"
+}
+
+variable "vm_cpu_sockets" {
+  type        = number
+  description = "The number of virtual CPUs sockets. (e.g. '2')"
+}
+
+variable "vm_cpu_cores" {
+  type        = number
+  description = "The number of virtual CPUs cores per socket. (e.g. '1')"
+}
+
+variable "vm_cpu_hot_add" {
+  type        = bool
+  description = "Enable hot add CPU."
+  default     = true
+}
+
+variable "vm_mem_size" {
+  type        = number
+  description = "The size for the virtual memory in MB. (e.g. '2048')"
+}
+
+variable "vm_mem_hot_add" {
+  type        = bool
+  description = "Enable hot add memory."
+  default     = true
+}
+
+variable "vm_disk_size" {
+  type        = number
+  description = "The size for the virtual disk in MB. (e.g. '40960')"
+}
+
+variable "vm_disk_controller_type" {
+  type        = list(string)
+  description = "The virtual disk controller types in sequence. (e.g. 'pvscsi')"
+  default     = ["pvscsi"]
+}
+
+variable "vm_disk_thin_provisioned" {
+  type        = bool
+  description = "Thin provision the virtual disk."
+  default     = true
+}
+
+variable "vm_network_card" {
+  type        = string
+  description = "The virtual network card type. (e.g. 'vmxnet3' or 'e1000e')"
+  default     = "vmxnet3"
+}
+
+variable "common_vm_version" {
+  type        = number
+  description = "The vSphere virtual hardware version. (e.g. '18')"
+}
+
+variable "common_tools_upgrade_policy" {
+  type        = bool
+  description = "Upgrade VMware Tools on reboot."
+  default     = true
+}
+
+variable "common_remove_cdrom" {
+  type        = bool
+  description = "Remove the virtual CD-ROM(s)."
+  default     = true
+}
+
+// Template and Content Library Settings
+
+variable "common_template_conversion" {
+  type        = bool
+  description = "Convert the virtual machine to template. Must be 'false' for content library."
+  default     = false
+}
+
+variable "common_content_library_name" {
+  type        = string
+  description = "The name of the target vSphere content library, if used. (e.g. 'sfo-w01-cl01-lib01')"
+  default     = null
+}
+
+variable "common_content_library_ovf" {
+  type        = bool
+  description = "Export to content library as an OVF template."
+  default     = true
+}
+
+variable "common_content_library_destroy" {
+  type        = bool
+  description = "Delete the virtual machine afer exporting to the content library."
+  default     = true
+}
+
+// Removable Media Settings
+
+variable "common_iso_datastore" {
+  type        = string
+  description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
+}
+
+variable "common_iso_path" {
+  type        = string
+  description = "The path on the source vSphere datastore for ISO images. (e.g. 'iso')"
+}
+
+variable "common_iso_hash" {
+  type        = string
+  description = "The algorithm used for the checkcum of the ISO image. (e.g. 'sha512')"
+}
+
+variable "iso_file" {
+  type        = string
+  description = "The file name of the ISO image. (e.g. 'iso-windows-server-2019.iso')"
+}
+
+variable "iso_checksum" {
+  type        = string
+  description = "The checksum of the ISO image. (e.g. Result of 'shasum -a 512 iso-windows-server-2019.iso')"
+}
+
+// Boot Settings
+
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source ('http' or 'disk')."
+}
+
+variable "common_http_port_min" {
+  type        = number
+  description = "The start of the HTTP port range."
+}
+
+variable "common_http_port_max" {
+  type        = number
+  description = "The end of the HTTP port range."
+}
+
+variable "vm_boot_order" {
+  type        = string
+  description = "The boot order for virtual machines devices."
+  default     = "disk,cdrom"
+}
+
+variable "vm_boot_wait" {
+  type        = string
+  description = "The time to wait before boot."
+}
+
+variable "vm_boot_command" {
+  type        = list(string)
+  description = "The virtual machine boot command."
+  default     = []
+}
+
+variable "vm_shutdown_command" {
+  type        = string
+  description = "Command(s) for guest operating system shutdown."
+}
+
+variable "common_ip_wait_timeout" {
+  type        = string
+  description = "Time to wait for guest operating system IP address response."
+}
+
+variable "common_shutdown_timeout" {
+  type        = string
+  description = "Time to wait for guest operating system shutdown."
+}
+
+// Communicator Settings and Credentials
+
+variable "build_username" {
+  type        = string
+  description = "The username to login to the guest operating system. (e.g. rainpole)"
+  sensitive   = true
+}
+
+variable "build_password" {
+  type        = string
+  description = "The password to login to the guest operating system."
+  sensitive   = true
+}
+
+variable "build_password_encrypted" {
+  type        = string
+  description = "The encrypted password to login to the guest operating system."
+  sensitive   = true
+  default     = ""
+}
+
+variable "build_key" {
+  type        = string
+  description = "The public key to login to the guest operating system."
+  sensitive   = true
+  default     = ""
+}
+
+// Communicator Credentials
+
+variable "communicator_port" {
+  type        = string
+  description = "The port for the communicator protocol."
+}
+
+variable "communicator_timeout" {
+  type        = string
+  description = "The timeout for the communicator protocol."
+}
+
+// Provisioner Settings
+
+variable "scripts" {
+  type        = list(string)
+  description = "A list of scripts and their relative paths to transfer and execute."
+  default     = []
+}
+
+variable "inline" {
+  type        = list(string)
+  description = "A list of commands to execute."
+  default     = []
+}

--- a/builds/windows/windows-10/windows.auto.pkrvars.hcl
+++ b/builds/windows/windows-10/windows.auto.pkrvars.hcl
@@ -1,0 +1,54 @@
+/*
+    DESCRIPTION:
+    Microsoft Windows 10 Pro variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
+*/
+
+// Installation Operating System Metadata
+vm_inst_os_language = "en-GB"
+vm_inst_os_keyboard = "en-GB"
+
+// Guest Operating System Metadata
+vm_guest_os_language = "en-US"
+vm_guest_os_keyboard = "en-US"
+vm_guest_os_timezone = "UTC"
+vm_guest_os_vendor   = "microsoft"
+vm_guest_os_family   = "windows"
+vm_guest_os_version  = "10"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "windows9_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware              = "efi-secure"
+vm_cdrom_type            = "sata"
+vm_cpu_sockets           = 2
+vm_cpu_cores             = 1
+vm_cpu_hot_add           = false
+vm_mem_size              = 2048
+vm_mem_hot_add           = false
+vm_disk_size             = 102400
+vm_disk_controller_type  = ["pvscsi"]
+vm_disk_thin_provisioned = true
+vm_network_card          = "vmxnet3"
+
+// Removable Media Settings
+iso_file     = "iso-windows-10.iso"
+iso_checksum = "a5a224237d79b605a761e912295a76de84c56ff9130ec99e98138d75c93ad6d2023cd7455eebb36a95462ece813bc5f58a90b319cbffcf0eb65cf7c43dd851cc"
+
+// Boot Settings
+vm_boot_order       = "disk,cdrom"
+vm_boot_wait        = "2s"
+vm_boot_command     = ["<spacebar>"]
+vm_shutdown_command = "shutdown /s /t 10 /f /d p:4:1 /c \"Shutdown by Packer\""
+
+// Communicator Settings
+communicator_port    = 5985
+communicator_timeout = "12h"
+
+// Provisioner Settings
+scripts = ["scripts/windows/windows-server-prepare.ps1"]
+inline = [
+  "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
+  "choco feature enable -n allowGlobalConfirmation",
+  "Get-EventLog -LogName * | ForEach { Clear-EventLog -LogName $_.Log }"
+]

--- a/builds/windows/windows-10/windows.auto.pkrvars.hcl
+++ b/builds/windows/windows-10/windows.auto.pkrvars.hcl
@@ -1,11 +1,11 @@
 /*
     DESCRIPTION:
-    Microsoft Windows 10 Pro variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
+    Microsoft Windows 10 Professional variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
 */
 
 // Installation Operating System Metadata
-vm_inst_os_language = "en-GB"
-vm_inst_os_keyboard = "en-GB"
+vm_inst_os_language = "en-US"
+vm_inst_os_keyboard = "en-US"
 
 // Guest Operating System Metadata
 vm_guest_os_language = "en-US"

--- a/builds/windows/windows-10/windows.pkr.hcl
+++ b/builds/windows/windows-10/windows.pkr.hcl
@@ -1,0 +1,172 @@
+/*
+    DESCRIPTION:
+    Microsoft Windows 10 Pro template using the Packer Builder for VMware vSphere (vsphere-iso).
+*/
+
+//  BLOCK: packer
+//  The Packer configuration.
+
+packer {
+  required_version = ">= 1.7.6"
+  required_plugins {
+    vsphere = {
+      version = ">= v1.0.1"
+      source  = "github.com/hashicorp/vsphere"
+    }
+  }
+  required_plugins {
+    windows-update = {
+      version = ">= 0.14.0"
+      source  = "github.com/rgl/windows-update"
+    }
+  }
+}
+
+//  BLOCK: locals
+//  Defines the local variables.
+
+locals {
+  buildtime     = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
+  path_manifest = "${path.cwd}/manifests/"
+}
+
+//  BLOCK: source
+//  Defines the builder configuration blocks.
+
+source "vsphere-iso" "windows-10-pro" {
+
+  // vCenter Server Endpoint Settings and Credentials
+  vcenter_server      = var.vsphere_endpoint
+  username            = var.vsphere_username
+  password            = var.vsphere_password
+  insecure_connection = var.vsphere_insecure_connection
+
+  // vSphere Settings
+  datacenter = var.vsphere_datacenter
+  cluster    = var.vsphere_cluster
+  datastore  = var.vsphere_datastore
+  folder     = var.vsphere_folder
+
+  // Virtual Machine Settings
+  guest_os_type        = var.vm_guest_os_type
+  vm_name              = "${var.vm_guest_os_family}-${var.vm_guest_os_version}-pro"
+  firmware             = var.vm_firmware
+  CPUs                 = var.vm_cpu_sockets
+  cpu_cores            = var.vm_cpu_cores
+  CPU_hot_plug         = var.vm_cpu_hot_add
+  RAM                  = var.vm_mem_size
+  RAM_hot_plug         = var.vm_mem_hot_add
+  cdrom_type           = var.vm_cdrom_type
+  disk_controller_type = var.vm_disk_controller_type
+  storage {
+    disk_size             = var.vm_disk_size
+    disk_thin_provisioned = var.vm_disk_thin_provisioned
+  }
+  network_adapters {
+    network      = var.vsphere_network
+    network_card = var.vm_network_card
+  }
+  vm_version           = var.common_vm_version
+  remove_cdrom         = var.common_remove_cdrom
+  tools_upgrade_policy = var.common_tools_upgrade_policy
+  notes                = "Built by HashiCorp Packer on ${local.buildtime}."
+
+  // Removable Media Settings
+  iso_paths    = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
+  iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
+  cd_files = [
+    "${path.cwd}/scripts/${var.vm_guest_os_family}/",
+    "${path.cwd}/certificates/"
+  ]
+  cd_content = {
+    "autounattend.xml" = templatefile("${abspath(path.root)}/data/autounattend.pkrtpl.hcl", {
+      os_image = "Windows 10 Pro"
+      kms_key  = "W269N-WFGWX-YVC9B-4J6C9-T83GX"
+
+      build_username = var.build_username
+      build_password = var.build_password
+
+      vm_inst_os_language = var.vm_inst_os_language
+      vm_inst_os_keyboard = var.vm_inst_os_keyboard
+
+      vm_guest_os_language = var.vm_guest_os_language
+      vm_guest_os_keyboard = var.vm_guest_os_keyboard
+      vm_guest_os_timezone = var.vm_guest_os_timezone
+    })
+  }
+
+  // Boot and Provisioning Settings
+  http_port_min    = var.common_http_port_min
+  http_port_max    = var.common_http_port_max
+  boot_order       = var.vm_boot_order
+  boot_wait        = var.vm_boot_wait
+  boot_command     = var.vm_boot_command
+  ip_wait_timeout  = var.common_ip_wait_timeout
+  shutdown_command = var.vm_shutdown_command
+  shutdown_timeout = var.common_shutdown_timeout
+
+  // Communicator Settings and Credentials
+  communicator   = "winrm"
+  winrm_username = var.build_username
+  winrm_password = var.build_password
+  winrm_port     = var.communicator_port
+  winrm_timeout  = var.communicator_timeout
+
+  // Template and Content Library Settings
+  convert_to_template = var.common_template_conversion
+  dynamic "content_library_destination" {
+    for_each = var.common_content_library_name != null ? [1] : []
+    content {
+      library = var.common_content_library_name
+      ovf     = var.common_content_library_ovf
+      destroy = var.common_content_library_destroy
+    }
+  }
+}
+
+//  BLOCK: build
+//  Defines the builders to run, provisioners, and post-processors.
+
+build {
+  sources = [
+    "source.vsphere-iso.windows-10-pro",
+  ]
+
+  provisioner "file" {
+    source      = "${path.cwd}/certificates/root-ca.p7b"
+    destination = "C:\\windows\\temp\\root-ca.p7b"
+  }
+
+  provisioner "powershell" {
+    environment_vars = [
+      "BUILD_USERNAME=${var.build_username}"
+    ]
+    elevated_user     = var.build_username
+    elevated_password = var.build_password
+    scripts           = formatlist("${path.cwd}/%s", var.scripts)
+  }
+
+  provisioner "powershell" {
+    elevated_user     = var.build_username
+    elevated_password = var.build_password
+    inline            = var.inline
+  }
+
+  provisioner "windows-update" {
+    pause_before    = "30s"
+    search_criteria = "IsInstalled=0"
+    filters = [
+      "exclude:$_.Title -like '*VMware*'",
+      "exclude:$_.Title -like '*Preview*'",
+      "exclude:$_.Title -like '*Defender*'",
+      "exclude:$_.InstallationBehavior.CanRequestUserInput",
+      "include:$true"
+    ]
+    restart_timeout = "120m"
+  }
+
+  post-processor "manifest" {
+    output     = "${local.path_manifest}${local.buildtime}-${var.vm_guest_os_family}.json"
+    strip_path = false
+  }
+}

--- a/builds/windows/windows-10/windows.pkr.hcl
+++ b/builds/windows/windows-10/windows.pkr.hcl
@@ -1,6 +1,6 @@
 /*
     DESCRIPTION:
-    Microsoft Windows 10 Pro template using the Packer Builder for VMware vSphere (vsphere-iso).
+    Microsoft Windows 10 Professional template using the Packer Builder for VMware vSphere (vsphere-iso).
 */
 
 //  BLOCK: packer
@@ -33,7 +33,7 @@ locals {
 //  BLOCK: source
 //  Defines the builder configuration blocks.
 
-source "vsphere-iso" "windows-10-pro" {
+source "vsphere-iso" "windows-10-professional" {
 
   // vCenter Server Endpoint Settings and Credentials
   vcenter_server      = var.vsphere_endpoint
@@ -49,7 +49,7 @@ source "vsphere-iso" "windows-10-pro" {
 
   // Virtual Machine Settings
   guest_os_type        = var.vm_guest_os_type
-  vm_name              = "${var.vm_guest_os_family}-${var.vm_guest_os_version}-pro"
+  vm_name              = "${var.vm_guest_os_family}-${var.vm_guest_os_version}-professional"
   firmware             = var.vm_firmware
   CPUs                 = var.vm_cpu_sockets
   cpu_cores            = var.vm_cpu_cores
@@ -129,7 +129,7 @@ source "vsphere-iso" "windows-10-pro" {
 
 build {
   sources = [
-    "source.vsphere-iso.windows-10-pro",
+    "source.vsphere-iso.windows-10-professional",
   ]
 
   provisioner "file" {
@@ -166,7 +166,7 @@ build {
   }
 
   post-processor "manifest" {
-    output     = "${local.path_manifest}${local.buildtime}-${var.vm_guest_os_family}.json"
+    output     = "${local.path_manifest}${local.buildtime}-${var.vm_guest_os_family}-professional.json"
     strip_path = false
   }
 }


### PR DESCRIPTION
**Summary of Pull Request**

Implement Windows 10 Pro image

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [X]  This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Add `windows-10` folder
- Copy `windows-server-2022` content to `windows-10` as base
- Update `variables.pkr.hcl`
  - Remove `vm_guest_os_member` variable, because only Windows
  - Remove `vm_guest_os_ed*` and `vm_guest_os_exp*` variables, because support only Windows 10 Pro
  - Create `vm_inst_os_language` and `vm_inst_os_keyboard` variables, because Windows 10 installer contains only one language. 
- Update `autounattended.pkrtpl.hcl`
  - Use `vm_inst_os_language` and `vm_inst_os_keyboard` variables on installer settings component
  - Add guest settings component for guest locale

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #87 

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [x] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
