### PR TITLE
Fix typo in `autounattend.pkrtpl.hcl`

### DIFF
--- a/builds/windows/windows-server-2016/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-server-2016/data/autounattend.pkrtpl.hcl
@@ -6,7 +6,7 @@
             <UILanguage>${vm_guest_os_language}</UILanguage>
          </SetupUILanguage>
          <InputLocale>${vm_guest_os_keyboard}</InputLocale>
-         <SystemLocale>e${vm_guest_os_language}</SystemLocale>
+         <SystemLocale>${vm_guest_os_language}</SystemLocale>
          <UILanguage>${vm_guest_os_language}</UILanguage>
          <UILanguageFallback>${vm_guest_os_language}</UILanguageFallback>
          <UserLocale>${vm_guest_os_language}</UserLocale>

--- a/builds/windows/windows-server-2019/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-server-2019/data/autounattend.pkrtpl.hcl
@@ -6,7 +6,7 @@
             <UILanguage>${vm_guest_os_language}</UILanguage>
          </SetupUILanguage>
          <InputLocale>${vm_guest_os_keyboard}</InputLocale>
-         <SystemLocale>e${vm_guest_os_language}</SystemLocale>
+         <SystemLocale>${vm_guest_os_language}</SystemLocale>
          <UILanguage>${vm_guest_os_language}</UILanguage>
          <UILanguageFallback>${vm_guest_os_language}</UILanguageFallback>
          <UserLocale>${vm_guest_os_language}</UserLocale>

--- a/builds/windows/windows-server-2022/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-server-2022/data/autounattend.pkrtpl.hcl
@@ -6,7 +6,7 @@
             <UILanguage>${vm_guest_os_language}</UILanguage>
          </SetupUILanguage>
          <InputLocale>${vm_guest_os_keyboard}</InputLocale>
-         <SystemLocale>e${vm_guest_os_language}</SystemLocale>
+         <SystemLocale>${vm_guest_os_language}</SystemLocale>
          <UILanguage>${vm_guest_os_language}</UILanguage>
          <UILanguageFallback>${vm_guest_os_language}</UILanguageFallback>
          <UserLocale>${vm_guest_os_language}</UserLocale>


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Fix typo in `autounattend.pkrtpl.hcl`
**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

Fixes typo for `<SystemLocale/>`value in `autounattend.pkrtpl.hcl`

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #86 
Closes: #86 

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
