### PR TITLE
Remove `<ComputerName/>` from `autounattend.pkrtpl.hcl`

### DIFF
--- a/builds/windows/windows-10/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-10/data/autounattend.pkrtpl.hcl
@@ -122,7 +122,6 @@
          <OEMInformation>
             <HelpCustomized>false</HelpCustomized>
          </OEMInformation>
-         <ComputerName>win-10-pro</ComputerName>
          <TimeZone>${vm_guest_os_timezone}</TimeZone>
          <RegisteredOwner />
       </component>

--- a/builds/windows/windows-server-2016/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-server-2016/data/autounattend.pkrtpl.hcl
@@ -122,7 +122,6 @@
          <OEMInformation>
             <HelpCustomized>false</HelpCustomized>
          </OEMInformation>
-         <ComputerName>win-server-2016</ComputerName>
          <TimeZone>${vm_guest_os_timezone}</TimeZone>
          <RegisteredOwner />
       </component>

--- a/builds/windows/windows-server-2019/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-server-2019/data/autounattend.pkrtpl.hcl
@@ -122,7 +122,6 @@
          <OEMInformation>
             <HelpCustomized>false</HelpCustomized>
          </OEMInformation>
-         <ComputerName>win-server-2019</ComputerName>
          <TimeZone>${vm_guest_os_timezone}</TimeZone>
          <RegisteredOwner />
       </component>

--- a/builds/windows/windows-server-2022/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/windows-server-2022/data/autounattend.pkrtpl.hcl
@@ -122,7 +122,6 @@
          <OEMInformation>
             <HelpCustomized>false</HelpCustomized>
          </OEMInformation>
-         <ComputerName>win-server-2022</ComputerName>
          <TimeZone>${vm_guest_os_timezone}</TimeZone>
          <RegisteredOwner />
       </component>


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Remove <ComputerName/> from autounattend.pkrtpl.hcl

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Removing `<ComputerName/>` from `autounattend.pkrtpl.hcl`
- Allows Windows OS to generate a name based off up to the first 7char of the organization name, a hyphen, and a 7char auto-generated string. (e.g. `RAINPOL-G8T2QG1`)
**Type of Pull Request**

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #90 
Closes: #90 

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
