### PR TITLE
Update Ubuntu 20.04 LTS to `efi-secure`

### DIFF
--- a/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.auto.pkrvars.hcl
@@ -16,7 +16,7 @@ vm_guest_os_version  = "20-04-lts"
 vm_guest_os_type = "ubuntu64Guest"
 
 // Virtual Machine Hardware Settings
-vm_firmware              = "bios"
+vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
 vm_cpu_sockets           = 2
 vm_cpu_cores             = 1

--- a/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
@@ -32,7 +32,7 @@ locals {
       vm_guest_os_timezone     = var.vm_guest_os_timezone
     })
   }
-  data_source_command = var.common_data_source == "http" ? "ds=nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/" : "ds=nocloud"
+  data_source_command = var.common_data_source == "http" ? "ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"" : "ds\"=nocloud\""
 }
 
 //  BLOCK: source
@@ -89,11 +89,14 @@ source "vsphere-iso" "linux-ubuntu-server" {
   http_port_max = var.common_data_source == "http" ? var.common_http_port_max : null
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
-  boot_command = [
-    "<enter><enter><f6><esc><wait> ",
-    "autoinstall ",
-    "${local.data_source_command} ",
-    "<enter><wait>"
+  boot_command  = [
+    "<esc><wait>",
+    "linux /casper/vmlinuz --- autoinstall ${local.data_source_command}",
+    "<enter><wait>",
+    "initrd /casper/initrd",
+    "<enter><wait>",
+    "boot",
+    "<enter>"
   ]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"

--- a/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
@@ -106,7 +106,7 @@ variable "vm_guest_os_type" {
 variable "vm_firmware" {
   type        = string
   description = "The virtual machine firmware. (e.g. 'efi-secure'. 'efi', or 'bios')"
-  default     = "bios"
+  default     = "efi-secure"
 }
 
 variable "vm_cdrom_type" {


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Update Ubuntu 20.04 LTS to `efi-secure`

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [X] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Update `vm_firmware` to `efi-secure` in `linux-photon.auto.pkrvars.hcl`
- Update `vm_firmware` default to `efi-secure` in `variables.hcl`
- Update `boot_command` in `linux-ubuntu-servrer.pkr.hcl` 

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
