### PR TITLE
Revert to Photon OS 4.0 GA from 4.0 Revision 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The files are distributed in the following directories.
 
     **Linux Distributions**
     * VMware Photon OS 4 Server
-        * [Download][download-linux-photon-server-4] the latest release of the **FULL** `.iso` image. (_e.g._ `photon-4.0-ca7c9e933.iso`)
+        * [Download][download-linux-photon-server-4] the 4.0 GA release of the **FULL** `.iso` image. (_e.g._ `photon-4.0-ca7c9e933.iso`)
     * Ubuntu Server 20.04 LTS
         * [Download][download-linux-ubuntu-server-20-04-lts] the latest **LIVE** release `.iso` image. (_e.g._ `ubuntu-20.04.2-live-server-amd64.iso`)
     * Ubuntu Server 18.04 LTS

--- a/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
+++ b/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
@@ -27,9 +27,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/linux/photon"
-iso_file           = "photon-4.0-ca7c9e933.iso"
+iso_file           = "photon-4.0-1526e30ba.iso"
 iso_checksum_type  = "md5"
-iso_checksum_value = "d8c4bc561e68afaf7815518f78a5b4ab"
+iso_checksum_value = "e0c77e9495c7bfaea20cc17be3cb145b"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Revert to Photon OS 4.0 GA from 4.0 Revision 1
**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

Reverting to Photon OS 4.0 GA from 4.0 Revision 1 due to #94. 

Will open an issue with vmware/photon to determine the cause of the issue in Rev1.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #94 

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [X] Tests have been completed (for bug fixes / features).
- [X] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
