### PR TITLE
Remove `sudo` from the `ks.pkrtpl.hcl` for rhel-derivatives

### DIFF
--- a/builds/linux/almalinux-8/data/ks.pkrtpl.hcl
+++ b/builds/linux/almalinux-8/data/ks.pkrtpl.hcl
@@ -24,10 +24,10 @@ reboot
 %end
 
 %post
-sudo dnf makecache
-sudo dnf install epel-release -y
-sudo dnf makecache
-sudo dnf install -y sudo open-vm-tools perl ansible
+dnf makecache
+dnf install epel-release -y
+dnf makecache
+dnf install -y sudo open-vm-tools perl ansible
 echo "${build_username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${build_username}
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 %end

--- a/builds/linux/centos-linux-8/data/ks.pkrtpl.hcl
+++ b/builds/linux/centos-linux-8/data/ks.pkrtpl.hcl
@@ -24,10 +24,10 @@ reboot
 %end
 
 %post
-sudo dnf makecache
-sudo dnf install epel-release -y
-sudo dnf makecache
-sudo dnf install -y sudo open-vm-tools perl ansible
+dnf makecache
+dnf install epel-release -y
+dnf makecache
+dnf install -y sudo open-vm-tools perl ansible
 echo "${build_username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${build_username}
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 %end

--- a/builds/linux/centos-stream-8/data/ks.pkrtpl.hcl
+++ b/builds/linux/centos-stream-8/data/ks.pkrtpl.hcl
@@ -24,10 +24,10 @@ reboot
 %end
 
 %post
-sudo dnf makecache
-sudo dnf install epel-release -y
-sudo dnf makecache
-sudo dnf install -y sudo open-vm-tools perl ansible
+dnf makecache
+dnf install epel-release -y
+dnf makecache
+dnf install -y sudo open-vm-tools perl ansible
 echo "${build_username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${build_username}
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 %end

--- a/builds/linux/rocky-linux-8/data/ks.pkrtpl.hcl
+++ b/builds/linux/rocky-linux-8/data/ks.pkrtpl.hcl
@@ -24,10 +24,10 @@ reboot
 %end
 
 %post
-sudo dnf makecache
-sudo dnf install epel-release -y
-sudo dnf makecache
-sudo dnf install -y sudo open-vm-tools perl ansible
+dnf makecache
+dnf install epel-release -y
+dnf makecache
+dnf install -y sudo open-vm-tools perl ansible
 echo "${build_username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${build_username}
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 %end


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Removes `sudo` from the `ks.pkrtpl.hcl` for rhel-derivatives.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [X] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

Remove `sudo` from the `ks.pkrtpl.hcl` for post-installation command (not required.)]

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
