### PR TITLE
Enable cloud-init `VMware` data source on Ubuntu 20.04 

### DIFF
--- a/builds/linux/ubuntu-server-20-04-lts/data/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/data/user-data.pkrtpl.hcl
@@ -187,6 +187,7 @@ autoinstall:
   packages:
     - openssh-server
     - open-vm-tools
+    - cloud-init
     - ansible
   user-data:
     disable_root: false


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Enables the cloud-init  `VMware` data source on Ubuntu 20.04 LTS with cloud-init 21.3+. (canonical/cloud-init 977)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

Enables the cloud-init `VMware` data source on Ubuntu 20.04 LTS with cloud-init 21.3+. (canonical/cloud-init 977)

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
